### PR TITLE
ALIS-2991 Modify lambda timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -83,6 +83,7 @@ package:
 functions:
   deposit:
     handler: src/handlers/deposit.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -97,6 +98,7 @@ functions:
 
   withdraw:
     handler: src/handlers/withdraw.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -112,6 +114,7 @@ functions:
 
   retryDeposit:
     handler: src/handlers/retry_deposit.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -122,6 +125,7 @@ functions:
 
   retryWithdraw:
     handler: src/handlers/retry_withdraw.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -132,6 +136,7 @@ functions:
 
   detectPendingDeposit:
     handler: src/handlers/detect_pending_deposit.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -152,6 +157,7 @@ functions:
 
   detectPendingWithdraw:
     handler: src/handlers/detect_pending_withdraw.handler
+    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,9 @@ provider:
     securityGroupIds:
       - ${env:VPC_SECURITY_GROUP_ID}
 
+  # Lambda
+  timeout: 60
+
 
 # Package
 package:
@@ -83,7 +86,6 @@ package:
 functions:
   deposit:
     handler: src/handlers/deposit.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -98,7 +100,6 @@ functions:
 
   withdraw:
     handler: src/handlers/withdraw.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -114,7 +115,6 @@ functions:
 
   retryDeposit:
     handler: src/handlers/retry_deposit.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -125,7 +125,6 @@ functions:
 
   retryWithdraw:
     handler: src/handlers/retry_withdraw.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -136,7 +135,6 @@ functions:
 
   detectPendingDeposit:
     handler: src/handlers/detect_pending_deposit.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 
@@ -157,7 +155,6 @@ functions:
 
   detectPendingWithdraw:
     handler: src/handlers/detect_pending_withdraw.handler
-    timeout: 60
     layers:
       - {Ref: PythonRequirementsLambdaLayer}
 


### PR DESCRIPTION
lambdaの処理がタイムアウトしてしまうため、タイムアウト時間を60秒に変更しました。