### PR TITLE
ALIS-3024 Fix retry apply relay

### DIFF
--- a/src/services/retry_apply_relay.py
+++ b/src/services/retry_apply_relay.py
@@ -1,4 +1,5 @@
 from web3 import Web3
+from eth_account import Account
 from src.services.helpers import contract
 from src.services.helpers.logger import logger
 
@@ -9,6 +10,10 @@ def execute(chain_config, private_key, relay_transactions):
     # Web3プロバイダーの生成
     provider_from = Web3.HTTPProvider(chain_config['chainRpcUrlFrom'])
     provider_to = Web3.HTTPProvider(chain_config['chainRpcUrlTo'])
+
+    # nonce設定のためトランザクション数の取得
+    nonce = _get_transaction_count(
+        provider_to, Account.privateKeyToAccount(private_key).address)
 
     # 各Relayイベントに対して、applyRelay処理を実行
     for relay_transaction in relay_transactions:
@@ -31,7 +36,11 @@ def execute(chain_config, private_key, relay_transactions):
                 private_key,
                 parsed_event['sender'], parsed_event['recipient'],
                 parsed_event['amount'], parsed_event['txHash'],
-                chain_config['gas'], chain_config['gasPrice'])
+                chain_config['gas'], chain_config['gasPrice'],
+                nonce)
+
+            # nonceのカウントアップ
+            nonce += 1
 
             logger.info(
                 '[ApplyRelay] txHash={txHash}, '

--- a/src/services/retry_apply_relay.py
+++ b/src/services/retry_apply_relay.py
@@ -43,3 +43,10 @@ def execute(chain_config, private_key, relay_transactions):
             continue
 
     logger.info('Finished')
+
+
+def _get_transaction_count(provider, account):
+    """ トランザクション数の取得
+    """
+    web3 = Web3(provider)
+    return web3.eth.getTransactionCount(web3.toChecksumAddress(account))

--- a/tests/services/test_retry_apply_relay.py
+++ b/tests/services/test_retry_apply_relay.py
@@ -9,10 +9,16 @@ class TestRetryApplyRelay(TestCase):
 
     @patch('src.services.helpers.contract.get_relay_event_log_by_tx_hash')
     @patch('src.services.helpers.contract.apply_relay')
-    def test_ok_retry_apply_relay(self, mock_apply_relay,
+    @patch('web3.eth.Eth.getTransactionCount')
+    def test_ok_retry_apply_relay(self, mock_get_transaction_count,
+                                  mock_apply_relay,
                                   mock_get_relay_event_log_by_tx_hash):
+        # Constants
+        TRANSACTION_COUNT = 10
+
         # Setup mock
         mock_apply_relay.return_value = '0x' + 'a' * 64
+        mock_get_transaction_count.return_value = TRANSACTION_COUNT
 
         def relay_event_log_side_effect(provider, hash):
             for log in mock_relay_log.data:
@@ -33,6 +39,7 @@ class TestRetryApplyRelay(TestCase):
             mock_apply_relay.call_count, len(mock_relay_log.data))
 
         # Assert parameters
+        nonce = TRANSACTION_COUNT
         apply_relay_calls = []
         for relay_event_log in mock_relay_log.data:
             apply_relay_calls.append(call(
@@ -43,6 +50,8 @@ class TestRetryApplyRelay(TestCase):
                 "0x" + relay_event_log['topics'][2].hex()[-40:],
                 int(relay_event_log['data'][2:66], 16),
                 relay_event_log['transactionHash'].hex(),
-                helper.CHAIN_CONFIG['gas'], helper.CHAIN_CONFIG['gasPrice']
+                helper.CHAIN_CONFIG['gas'], helper.CHAIN_CONFIG['gasPrice'],
+                nonce
             ))
+            nonce += 1
         mock_apply_relay.assert_has_calls(apply_relay_calls)


### PR DESCRIPTION
メソッド呼び出しの引数指定のミスです。
テストケースに引数チェック処理を追加し、バグを修正しました。