### PR TITLE
ALIS-2956 Modify chain_config.yml

### DIFF
--- a/chain_config.yml
+++ b/chain_config.yml
@@ -2,12 +2,12 @@
 public:
   rpcUrl: ${ssm:${env:ALIS_APP_ID}ssmPublicChainOperationUrl}
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPublicChainBridgeAddress}
-  gas: 5500000
-  gasPrice: 1000000000
+  gas: 200000
+  gasPrice: 13000000000
 
 # Private chain
 private:
   rpcUrl: ${ssm:${env:ALIS_APP_ID}ssmPrivateChainOperationUrl}
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPrivateChainBridgeAddress}
-  gas: 3500000 # NOTICE プライベートチェーン側もgasは指定しないとトランザクションに失敗する
+  gas: 200000 # NOTICE プライベートチェーン側もgasは指定しないとトランザクションに失敗する
   gasPrice: 0


### PR DESCRIPTION
■ ガスリミット
200000に設定しました。

【理由】
トランザクション実行におよそ60000〜90000のガスが消費されていたため、余裕を持って200000あれば十分と思われる


■ ガスプライス
13GWEIに設定しました。

【理由】
・初期はガスのスパイク等も考慮し、十分に大きな値にする
・3GWEIでマイニングされるまでの平均時間が約1分程（gastrackerを参照）
　　https://etherscan.io/gastracker

・ガスにかかる最大コストは手数料以下
　最大ガスコスト
　　200000 x 13GWEI = 0.0026ETH = 48Yen
　手数料
　　20ALIS x 5Yen = 100Yen