### PR TITLE
Change gas price to 20 gwei

### DIFF
--- a/chain_config.yml
+++ b/chain_config.yml
@@ -3,7 +3,7 @@ public:
   rpcUrl: ${ssm:${env:ALIS_APP_ID}ssmPublicChainOperationUrl}
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPublicChainBridgeAddress}
   gas: 200000
-  gasPrice: 35000000000
+  gasPrice: 20000000000
 
 # Private chain
 private:


### PR DESCRIPTION
Ethereumの平均ガス価格が安定してきたため、オペレータのガス設定値を35gwei->20gweiに戻しました。