### PR TITLE
ALIS-5349 Change gas price dynamically

### DIFF
--- a/chain_config.yml
+++ b/chain_config.yml
@@ -4,6 +4,7 @@ public:
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPublicChainBridgeAddress}
   gas: 200000
   gasPrice: 35000000000
+  maxGasPrice: 80000000000
 
 # Private chain
 private:
@@ -11,3 +12,4 @@ private:
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPrivateChainBridgeAddress}
   gas: 200000 # NOTICE プライベートチェーン側もgasは指定しないとトランザクションに失敗する
   gasPrice: 0
+  maxGasPrice: 0

--- a/serverless.yml
+++ b/serverless.yml
@@ -116,7 +116,7 @@ functions:
     # Function specific environments
     environment:
       PUBLIC_CHAIN_GAS: ${file(./chain_config.yml):public.gas}
-      PUBLIC_CHAIN_GAS_PRICE: ${file(./chain_config.yml):public.gasPrice}
+      PUBLIC_CHAIN_MAX_GAS_PRICE: ${file(./chain_config.yml):public.maxGasPrice}
 
   retryDeposit:
     handler: src/handlers/retry_deposit.handler

--- a/src/handlers/helpers/helper.py
+++ b/src/handlers/helpers/helper.py
@@ -25,7 +25,8 @@ def load_chain_config(is_deposit):
             'gas': (os.environ['PRIVATE_CHAIN_GAS']
                     if 'PRIVATE_CHAIN_GAS' in os.environ else ''),
             'gasPrice': (os.environ['PRIVATE_CHAIN_GAS_PRICE']
-                         if 'PRIVATE_CHAIN_GAS_PRICE' in os.environ else '')
+                         if 'PRIVATE_CHAIN_GAS_PRICE' in os.environ else ''),
+            'maxGasPrice': os.environ.get('PRIVATE_CHAIN_MAX_GAS_PRICE', '')
         }
     else:
         # 出金時
@@ -40,7 +41,8 @@ def load_chain_config(is_deposit):
             'gas': (os.environ['PUBLIC_CHAIN_GAS']
                     if 'PUBLIC_CHAIN_GAS' in os.environ else ''),
             'gasPrice': (os.environ['PUBLIC_CHAIN_GAS_PRICE']
-                         if 'PUBLIC_CHAIN_GAS_PRICE' in os.environ else '')
+                         if 'PUBLIC_CHAIN_GAS_PRICE' in os.environ else ''),
+            'maxGasPrice': os.environ.get('PUBLIC_CHAIN_MAX_GAS_PRICE', '')
         }
 
 

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -65,6 +65,7 @@ def execute(chain_config, dynamo_table, private_key):
                 parsed_event['txHash'],
                 chain_config['gas'],
                 chain_config['gasPrice'],
+                chain_config['maxGasPrice'],
                 nonce)
 
             # nonceのカウントアップ

--- a/src/services/helpers/contract.py
+++ b/src/services/helpers/contract.py
@@ -7,7 +7,8 @@ with open('abi/Bridge.json', 'rt') as file:
 
 
 def apply_relay(provider, contract_address, private_key, sender,
-                recipient, amount, txHash, gas, gasPrice, nonce):
+                recipient, amount, txHash, gas, gas_price, max_gas_price,
+                nonce):
     """ applyRelayの実行
     """
     if BRIDGE_ABI is None:
@@ -18,13 +19,16 @@ def apply_relay(provider, contract_address, private_key, sender,
     contract = web3.eth.contract(
         web3.toChecksumAddress(contract_address), abi=BRIDGE_ABI)
 
+    if len(gas_price) <= 0:
+        gas_price = min(web3.eth.gasPrice, int(max_gas_price))
+
     transaction = contract.functions.applyRelay(
         web3.toChecksumAddress(sender),
         web3.toChecksumAddress(recipient),
         amount, txHash).buildTransaction({
             'nonce': nonce,
             'gas': hex(int(gas)),
-            'gasPrice': hex(int(gasPrice))
+            'gasPrice': hex(int(gas_price))
         })
 
     signed_transaction = web3.eth.account.signTransaction(

--- a/src/services/retry_apply_relay.py
+++ b/src/services/retry_apply_relay.py
@@ -37,6 +37,7 @@ def execute(chain_config, private_key, relay_transactions):
                 parsed_event['sender'], parsed_event['recipient'],
                 parsed_event['amount'], parsed_event['txHash'],
                 chain_config['gas'], chain_config['gasPrice'],
+                chain_config['maxGasPrice'],
                 nonce)
 
             # nonceのカウントアップ

--- a/tests/handlers/helpers/test_helper.py
+++ b/tests/handlers/helpers/test_helper.py
@@ -12,10 +12,12 @@ class TestHelper(TestCase):
         os.environ['PUBLIC_CHAIN_BRIDGE_CONTRACT_ADDRESS'] = '0x' + 'a' * 40
         os.environ['PUBLIC_CHAIN_GAS'] = '100'
         os.environ['PUBLIC_CHAIN_GAS_PRICE'] = '10000'
+        os.environ['PUBLIC_CHAIN_MAX_GAS_PRICE'] = '50000'
         os.environ['PRIVATE_CHAIN_RPC_URL'] = 'http://example2.com'
         os.environ['PRIVATE_CHAIN_BRIDGE_CONTRACT_ADDRESS'] = '0x' + 'b' * 40
         os.environ['PRIVATE_CHAIN_GAS'] = '200'
         os.environ['PRIVATE_CHAIN_GAS_PRICE'] = '20000'
+        os.environ['PRIVATE_CHAIN_MAX_GAS_PRICE'] = '60000'
 
         # Execute load_chain_config (for Deposit)
         deposit_config = helper.load_chain_config(True)
@@ -30,7 +32,8 @@ class TestHelper(TestCase):
             'bridgeContractAddressTo':
                 os.environ['PRIVATE_CHAIN_BRIDGE_CONTRACT_ADDRESS'],
             'gas': os.environ['PRIVATE_CHAIN_GAS'],
-            'gasPrice': os.environ['PRIVATE_CHAIN_GAS_PRICE']
+            'gasPrice': os.environ['PRIVATE_CHAIN_GAS_PRICE'],
+            'maxGasPrice': os.environ['PRIVATE_CHAIN_MAX_GAS_PRICE']
         })
 
         # Execute load_chain_config (for Withdraw)
@@ -46,7 +49,8 @@ class TestHelper(TestCase):
             'bridgeContractAddressTo':
                 os.environ['PUBLIC_CHAIN_BRIDGE_CONTRACT_ADDRESS'],
             'gas': os.environ['PUBLIC_CHAIN_GAS'],
-            'gasPrice': os.environ['PUBLIC_CHAIN_GAS_PRICE']
+            'gasPrice': os.environ['PUBLIC_CHAIN_GAS_PRICE'],
+            'maxGasPrice': os.environ['PUBLIC_CHAIN_MAX_GAS_PRICE']
         })
 
     @patch('boto3.client')

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -7,7 +7,8 @@ CHAIN_CONFIG = {
     'chainRpcUrlTo': 'http://example.com',
     'bridgeContractAddressTo': '0x' + 'b' * 40,
     'gas': '5500000',
-    'gasPrice': '1000000000'
+    'gasPrice': '1000000000',
+    'maxGasPrice': '5000000000'
 }
 
 PRIVATE_KEY = "0x" + "c" * 64

--- a/tests/services/test_bridge.py
+++ b/tests/services/test_bridge.py
@@ -51,6 +51,7 @@ class TestBridge(TestCase):
                 int(relay_event_log['data'][2:66], 16),
                 relay_event_log['transactionHash'].hex(),
                 helper.CHAIN_CONFIG['gas'], helper.CHAIN_CONFIG['gasPrice'],
+                helper.CHAIN_CONFIG['maxGasPrice'],
                 nonce
             ))
             nonce += 1
@@ -111,6 +112,7 @@ class TestBridge(TestCase):
                 int(relay_event_log['data'][2:66], 16),
                 relay_event_log['transactionHash'].hex(),
                 helper.CHAIN_CONFIG['gas'], helper.CHAIN_CONFIG['gasPrice'],
+                helper.CHAIN_CONFIG['maxGasPrice'],
                 nonce
             ))
             nonce += 1

--- a/tests/services/test_retry_apply_relay.py
+++ b/tests/services/test_retry_apply_relay.py
@@ -51,6 +51,7 @@ class TestRetryApplyRelay(TestCase):
                 int(relay_event_log['data'][2:66], 16),
                 relay_event_log['transactionHash'].hex(),
                 helper.CHAIN_CONFIG['gas'], helper.CHAIN_CONFIG['gasPrice'],
+                helper.CHAIN_CONFIG['maxGasPrice'],
                 nonce
             ))
             nonce += 1


### PR DESCRIPTION
■ 対応方針
・出金時のガス価格を直近の数ブロックにおけるガス価格の中央値（EthereumノードのRPCで取得可能）に設定する
・ただし、ガス価格は大きくスパイクすることがあるため、最大値を指定してその値を超えないようにする（最大値は80Gweiに指定）