### PR TITLE
ALIS-5635

### DIFF
--- a/chain_config.yml
+++ b/chain_config.yml
@@ -4,7 +4,7 @@ public:
   bridgeContractAddress: ${ssm:${env:ALIS_APP_ID}ssmPublicChainBridgeAddress}
   gas: 200000
   gasPrice: 35000000000
-  maxGasPrice: 80000000000
+  maxGasPrice: 120000000000
 
 # Private chain
 private:


### PR DESCRIPTION
内容をご確認いただき、マージをお願いします。
ガス価格設定値の最大値を80gwei -> 120gweiに変更しました。